### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides network packet capture and analysis capabilities through Wireshark/tshark integration. Designed for AI assistants to perform network security analysis, troubleshooting, and packet inspection.
 
+<a href="https://glama.ai/mcp/servers/@kriztalz/SharkMCP">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kriztalz/SharkMCP/badge" alt="SharkMCP MCP server" />
+</a>
+
 This server was thought for situations where you want your agent to debug a program that sends requests and verify the packet traffic, allowing the following workflow:
 
 - Start recording packets


### PR DESCRIPTION
This PR adds a badge for the [SharkMCP](https://glama.ai/mcp/servers/@kriztalz/SharkMCP) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@kriztalz/SharkMCP">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kriztalz/SharkMCP/badge" alt="SharkMCP MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.